### PR TITLE
Reconnect on immediate disconnect

### DIFF
--- a/lib/bluetooth-manager.js
+++ b/lib/bluetooth-manager.js
@@ -9,6 +9,8 @@ let _delegate;
 function BluetoothManager(delegate) {
   _delegate = delegate;
   this.peripheral = null;
+  this.discoverSuccess = false;
+  this.discoverFailures = 0;
   noble.on('stateChange', this.onStateChange.bind(this));
   noble.on('discover', this.didDiscover.bind(this));
   noble.on('scanStart', () => debug('on -> scanStart'));
@@ -39,6 +41,8 @@ BluetoothManager.prototype.didDiscover = function(peripheral) {
   noble.stopScanning();
   peripheral.once('connect', () => {
     debug('on -> connect');
+    this.discoverSuccess = false;
+    this.discoverFailures = 0;
     peripheral.once('servicesDiscover', this.didDiscoverServices.bind(this));
     peripheral.discoverServices([UUID.TransmitterService.CGMService]);
   });
@@ -47,16 +51,25 @@ BluetoothManager.prototype.didDiscover = function(peripheral) {
     this.peripheral = null;
     peripheral.removeAllListeners();
 
-    // on the event of disconnect, do something like the following:
-    // if (outstandingPromise) { // can this be a stand-in to check if the transmitter is still mid-operation?
-    //   debug('forced disconnect - scanning again');
-    //   this.scanForPeripheral();
-    // }
-    // else {
-    debug('scanning again in 1 minute');
-    setTimeout(this.scanForPeripheral.bind(this), 60000); // TODO: consider scanning again 4.5 minutes after last connect (could save power?)
-    // }
-    _delegate.didDisconnect();
+    if (!this.discoverSuccess && (this.discoverFailures < 3)) {
+      ++this.discoverFailures;
+
+      debug('trying to reconnect... '+this.discoverFailures);
+
+      this.didDiscover(this.peripheral);
+    } else {
+
+      // on the event of disconnect, do something like the following:
+      // if (outstandingPromise) { // can this be a stand-in to check if the transmitter is still mid-operation?
+      //   debug('forced disconnect - scanning again');
+      //   this.scanForPeripheral();
+      // }
+      // else {
+      debug('scanning again in 1 minute');
+      setTimeout(this.scanForPeripheral.bind(this), 60000); // TODO: consider scanning again 4.5 minutes after last connect (could save power?)
+      // }
+      _delegate.didDisconnect();
+    }
   });
   peripheral.connect();
 };
@@ -66,6 +79,9 @@ BluetoothManager.prototype.didDiscoverServices = function(services) {
   // we only searched for one service; assume we only got one
   service = services[0];
   if (service.uuid !== UUID.TransmitterService.CGMService) return;
+
+  this.discoverSuccess = true;
+
   service.once('characteristicsDiscover', this.didDiscoverCharacteristics.bind(this));
   service.discoverCharacteristics();
 };

--- a/lib/bluetooth-manager.js
+++ b/lib/bluetooth-manager.js
@@ -22,6 +22,7 @@ BluetoothManager.prototype.onStateChange = function(state) {
 
   if (state === 'poweredOn') {
     debug('starting scanning');
+    this.discoverFailures = 0;
     this.scanForPeripheral();
   } else {
     debug('stopping scanning');
@@ -42,7 +43,6 @@ BluetoothManager.prototype.didDiscover = function(peripheral) {
   peripheral.once('connect', () => {
     debug('on -> connect');
     this.discoverSuccess = false;
-    this.discoverFailures = 0;
     peripheral.once('servicesDiscover', this.didDiscoverServices.bind(this));
     peripheral.discoverServices([UUID.TransmitterService.CGMService]);
   });

--- a/lib/bluetooth-manager.js
+++ b/lib/bluetooth-manager.js
@@ -56,7 +56,7 @@ BluetoothManager.prototype.didDiscover = function(peripheral) {
 
       debug('trying to reconnect... '+this.discoverFailures);
 
-      this.didDiscover(this.peripheral);
+      this.didDiscover(peripheral);
     } else {
 
       // on the event of disconnect, do something like the following:


### PR DESCRIPTION
About 15% of the time, the transmitter would disconnect before any services were discovered. This pull request modifies bluetooth-manager.js such that in when the transmitter disconnect before any services are discovered, it immediately tries to reconnect up to 3 times before giving up and trying again in 1 minute.